### PR TITLE
Fix correctness issues and add iterative selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The current package is organized around three main extension points:
 - `Embedder`: text-to-vector protocol
 - `CandidateSource`: candidate retrieval protocol
 - `PsiLoop`: thin orchestration shell that fetches candidates, scores them, and fits them to a budget
+- `build_task_forensics` / `render_task_forensics`: structured forensic view comparing `Psi0` and baseline on a single task
 
 The default install path remains zero-dependency:
 
@@ -94,7 +95,9 @@ The default install path remains zero-dependency:
 
 The package ranks candidates by `H * V` (with near-tie value-priority at selection time), then fits the result into a shared token budget. A similarity-only baseline is included for comparison so fixtures can demonstrate where goal-conditioned salience beats naive retrieval.
 
-By default, `H` is still computed through the bundled `BowEmbedder`, which preserves the current bag-of-words behavior. The scoring functions now also accept injected embedders, which is the seam intended for future dense-vector backends.
+By default, `H` is computed through the bundled `BowEmbedder`, which produces L2-normalized bag-of-words vectors so that short and long chunks contribute equally to the context centroid. The scoring functions also accept injected embedders, which is the seam intended for future dense-vector backends.
+
+Selection is **iterative by default**: after each candidate is chosen it is appended to the running context before the remaining candidates are re-scored, so already-selected content suppresses redundant subsequent picks. Pass `iterative=False` to `select_context` or `PsiLoop.select` to restore the original single-pass behaviour.
 
 In the bundled example, the baseline prefers a note that repeats the existing fixed-delay retry policy, while `Psi0` prefers the more novel note about exponential backoff with jitter.
 

--- a/src/psi_loop/__init__.py
+++ b/src/psi_loop/__init__.py
@@ -2,6 +2,7 @@
 
 from psi_loop.baseline import baseline_score, select_context_baseline
 from psi_loop.embedders import BowEmbedder, Embedder, STEmbedder
+from psi_loop.forensics import build_task_forensics, render_task_forensics
 from psi_loop.models import Candidate, ScoredCandidate, SelectionResult, SourceRequest, TaskDefinition
 from psi_loop.pipeline import PsiLoop, select_context
 from psi_loop.scoring import goal_similarity, keyword_overlap, psi_0, surprise_score
@@ -9,12 +10,14 @@ from psi_loop.sources import CandidateSource, FixtureSource
 
 __all__ = [
     "baseline_score",
+    "build_task_forensics",
     "BowEmbedder",
     "Candidate",
     "CandidateSource",
     "Embedder",
     "FixtureSource",
     "goal_similarity",
+    "render_task_forensics",
     "ScoredCandidate",
     "SelectionResult",
     "PsiLoop",

--- a/src/psi_loop/embedders.py
+++ b/src/psi_loop/embedders.py
@@ -20,11 +20,20 @@ class Embedder(Protocol):
 
 
 class BowEmbedder:
-    """Default embedder that preserves the current bag-of-words behavior."""
+    """Default embedder using L2-normalized bag-of-words vectors.
+
+    Normalizing to unit length removes document-length bias from centroid
+    calculations, so a 3-word chunk and a 300-word chunk contribute equally
+    to the context centroid when computing surprise scores.
+    """
 
     def embed(self, text: str) -> SparseVector:
         counts = token_counts(text)
-        return {token: float(value) for token, value in counts.items()}
+        raw = {token: float(value) for token, value in counts.items()}
+        norm = sum(v * v for v in raw.values()) ** 0.5
+        if norm == 0.0:
+            return raw
+        return {token: value / norm for token, value in raw.items()}
 
 
 class STEmbedder:

--- a/src/psi_loop/forensics.py
+++ b/src/psi_loop/forensics.py
@@ -133,7 +133,13 @@ def build_task_forensics(
     embedder: Embedder | None = None,
     top_k: int = 5,
 ) -> TaskForensics:
-    """Build a structured forensic view for one task."""
+    """Build a structured forensic view for one task.
+
+    Uses iterative=False so that the budget trace (which replays selection over
+    the initial ranked list) stays consistent with the reported selected set.
+    Iterative selection interleaves scoring and selection in a way that cannot
+    be faithfully replayed by a post-hoc budget trace over a static ranking.
+    """
 
     baseline_result = select_context_baseline(
         candidates=task.candidates,
@@ -147,6 +153,7 @@ def build_task_forensics(
         current_context=task.current_context,
         max_tokens=task.max_tokens,
         embedder=embedder,
+        iterative=False,
     )
     return TaskForensics(
         task_id=task.id,

--- a/src/psi_loop/pipeline.py
+++ b/src/psi_loop/pipeline.py
@@ -22,6 +22,16 @@ def _token_count(text: str) -> int:
     return len(tokenize(text))
 
 
+def _near_tie_sort_key(item: ScoredCandidate) -> tuple[float, float, float, str]:
+    """Shared sort key for both initial ranking and iterative rescoring rounds.
+
+    Buckets scores into NEAR_TIE_EPSILON-wide windows so that near-tie candidates
+    are ranked by value (higher V first) rather than by sub-epsilon score jitter.
+    """
+    score_bucket = (item.score // NEAR_TIE_EPSILON) * NEAR_TIE_EPSILON
+    return (-score_bucket, -item.value, -item.surprise, item.candidate.id)
+
+
 def rank_candidates(
     candidates: Sequence[Candidate],
     goal: str,
@@ -31,9 +41,9 @@ def rank_candidates(
 ) -> list[ScoredCandidate]:
     """Rank candidates with Psi0 and preserve useful scoring detail.
 
-    When two scores differ by less than NEAR_TIE_EPSILON, the candidate with higher
-    value is ranked first (near-tie V-priority) so budget packing prefers usefulness
-    over novelty in close score contests.
+    When two scores fall in the same NEAR_TIE_EPSILON bucket, the candidate with
+    higher value is ranked first (near-tie V-priority) so budget packing prefers
+    usefulness over novelty in close score contests.
     """
 
     ranked: list[ScoredCandidate] = []
@@ -54,11 +64,7 @@ def rank_candidates(
             )
         )
 
-    def sort_key(item: ScoredCandidate) -> tuple[float, float, float, str]:
-        score_bucket = (item.score // NEAR_TIE_EPSILON) * NEAR_TIE_EPSILON
-        return (-score_bucket, -item.value, -item.surprise, item.candidate.id)
-
-    return sorted(ranked, key=sort_key)
+    return sorted(ranked, key=_near_tie_sort_key)
 
 
 def fit_to_budget(ranked: Sequence[ScoredCandidate], max_tokens: int) -> list[ScoredCandidate]:
@@ -117,7 +123,7 @@ def _select_iterative(
                 )
             )
 
-        scored.sort(key=lambda x: (-x.score, -x.value, x.candidate.id))
+        scored.sort(key=_near_tie_sort_key)
 
         # Pick the highest-scoring candidate that fits in the remaining budget.
         picked: ScoredCandidate | None = None

--- a/src/psi_loop/pipeline.py
+++ b/src/psi_loop/pipeline.py
@@ -11,7 +11,10 @@ from psi_loop.scoring import psi_0, tokenize
 
 CandidateScorer = Callable[[str, str, Iterable[str], Embedder | None], tuple[float, float, float]]
 
-# When two scores differ by less than this, rank by value (higher V first) before budget packing.
+# Scores within the same NEAR_TIE_EPSILON-wide floor-division bucket are treated as near-ties
+# and ranked by value (higher V first) before budget packing.  This is implemented as floor
+# division, so the guarantee is per-bucket, not per-pair: two scores that straddle a bucket
+# boundary may differ by less than NEAR_TIE_EPSILON yet still land in different buckets.
 NEAR_TIE_EPSILON = 1e-2
 
 
@@ -59,7 +62,12 @@ def rank_candidates(
 
 
 def fit_to_budget(ranked: Sequence[ScoredCandidate], max_tokens: int) -> list[ScoredCandidate]:
-    """Take the highest-value items that fit within the token budget."""
+    """Take the highest-scoring items that fit within the token budget.
+
+    Scores are fixed before selection begins — selected candidates do not
+    update the context centroid.  Use select_context (iterative=True) when
+    you want each selection to suppress redundant subsequent picks.
+    """
 
     selected: list[ScoredCandidate] = []
     tokens_used = 0
@@ -73,23 +81,94 @@ def fit_to_budget(ranked: Sequence[ScoredCandidate], max_tokens: int) -> list[Sc
     return selected
 
 
+def _select_iterative(
+    candidates: Sequence[Candidate],
+    goal: str,
+    current_context: list[str],
+    max_tokens: int,
+    scorer: CandidateScorer,
+    embedder: Embedder | None,
+) -> list[ScoredCandidate]:
+    """Greedy iterative selection: re-score remaining candidates after each pick.
+
+    Each selected candidate is appended to the running context before the next
+    round of scoring, so already-selected content suppresses redundant picks —
+    not just the original current_context.  This makes the redundancy guarantee
+    hold within the selected set, not just against pre-existing context.
+    """
+
+    running_context = list(current_context)
+    remaining: list[Candidate] = list(candidates)
+    selected: list[ScoredCandidate] = []
+    tokens_used = 0
+
+    while remaining:
+        # Score all remaining candidates against the running context.
+        scored: list[ScoredCandidate] = []
+        for candidate in remaining:
+            score, value, surprise = scorer(candidate.text, goal, running_context, embedder)
+            scored.append(
+                ScoredCandidate(
+                    candidate=candidate,
+                    score=score,
+                    value=value,
+                    surprise=surprise,
+                    token_count=_token_count(candidate.text),
+                )
+            )
+
+        scored.sort(key=lambda x: (-x.score, -x.value, x.candidate.id))
+
+        # Pick the highest-scoring candidate that fits in the remaining budget.
+        picked: ScoredCandidate | None = None
+        for item in scored:
+            if item.token_count <= max_tokens and tokens_used + item.token_count <= max_tokens:
+                picked = item
+                break
+
+        if picked is None:
+            break  # Nothing fits — done.
+
+        selected.append(picked)
+        tokens_used += picked.token_count
+        running_context.append(picked.candidate.text)
+        remaining = [c for c in remaining if c.id != picked.candidate.id]
+
+    return selected
+
+
 def select_context(
     candidates: Sequence[Candidate],
     goal: str,
     current_context: Iterable[str],
     max_tokens: int,
     embedder: Embedder | None = None,
+    iterative: bool = True,
 ) -> SelectionResult:
-    """Rank and select candidates under a shared token budget."""
+    """Rank and select candidates under a shared token budget.
 
+    When iterative=True (default), each selected candidate updates the running
+    context before scoring the next round, so selected items suppress redundant
+    subsequent picks.  Set iterative=False to use the original single-pass
+    fit_to_budget behaviour.
+    """
+
+    context_items = list(current_context)
+
+    # Always produce a full initial ranking for inspection / forensics.
     ranked = rank_candidates(
         candidates,
         goal,
-        current_context,
+        context_items,
         scorer=psi_0,
         embedder=embedder,
     )
-    selected = fit_to_budget(ranked, max_tokens)
+
+    if iterative:
+        selected = _select_iterative(candidates, goal, context_items, max_tokens, psi_0, embedder)
+    else:
+        selected = fit_to_budget(ranked, max_tokens)
+
     return SelectionResult(ranked=ranked, selected=selected, max_tokens=max_tokens)
 
 
@@ -100,17 +179,24 @@ def select_with_scorer(
     max_tokens: int,
     scorer: CandidateScorer,
     embedder: Embedder | None = None,
+    iterative: bool = True,
 ) -> SelectionResult:
     """Shared selection entrypoint for pluggable scoring strategies."""
 
+    context_items = list(current_context)
     ranked = rank_candidates(
         candidates,
         goal,
-        current_context,
+        context_items,
         scorer=scorer,
         embedder=embedder,
     )
-    selected = fit_to_budget(ranked, max_tokens)
+
+    if iterative:
+        selected = _select_iterative(candidates, goal, context_items, max_tokens, scorer, embedder)
+    else:
+        selected = fit_to_budget(ranked, max_tokens)
+
     return SelectionResult(ranked=ranked, selected=selected, max_tokens=max_tokens)
 
 
@@ -135,6 +221,7 @@ class PsiLoop:
         candidates: Sequence[Candidate] | None = None,
         fetch_k: int | None = None,
         task_id: str | None = None,
+        iterative: bool = True,
     ) -> SelectionResult:
         """Select context from provided candidates or a configured source."""
 
@@ -157,4 +244,5 @@ class PsiLoop:
             max_tokens=max_tokens,
             scorer=self.scorer,
             embedder=self.embedder,
+            iterative=iterative,
         )

--- a/src/psi_loop/pipeline.py
+++ b/src/psi_loop/pipeline.py
@@ -138,7 +138,7 @@ def _select_iterative(
         selected.append(picked)
         tokens_used += picked.token_count
         running_context.append(picked.candidate.text)
-        remaining = [c for c in remaining if c.id != picked.candidate.id]
+        remaining = [c for c in remaining if c is not picked.candidate]
 
     return selected
 

--- a/tests/test_comprehensive_review.py
+++ b/tests/test_comprehensive_review.py
@@ -1,0 +1,741 @@
+"""Comprehensive review tests for psi-loop — edge cases, invariants, and behavioral checks."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from psi_loop import (
+    BowEmbedder,
+    Candidate,
+    FixtureSource,
+    PsiLoop,
+    SelectionResult,
+    SourceRequest,
+    keyword_overlap,
+    psi_0,
+    select_context,
+    select_context_baseline,
+    surprise_score,
+)
+from psi_loop.embedders import centroid, cosine_similarity_vectors
+from psi_loop.pipeline import NEAR_TIE_EPSILON, fit_to_budget, rank_candidates
+from psi_loop.scoring import (
+    GENERIC_GOAL_TERMS,
+    ACTION_MECHANISM_TERMS,
+    PLAN_BONUS_ALPHA,
+    _goal_is_planning_shaped,
+    _plan_structure_score,
+    _value_with_plan_bonus,
+    goal_term_weight,
+)
+from psi_loop.text import tokenize, token_counts
+
+
+# ---------------------------------------------------------------------------
+# Section 1: Text / tokenization edge cases
+# ---------------------------------------------------------------------------
+
+class TestTokenize:
+    def test_empty_string_returns_empty_list(self):
+        assert tokenize("") == []
+
+    def test_stopwords_are_removed(self):
+        tokens = tokenize("a an and are as at be for from in")
+        assert tokens == []
+
+    def test_stemming_ing_suffix(self):
+        # "retrying" -> strip "ing" -> "retry" (len("retrying")=8 > 5)
+        tokens = tokenize("retrying")
+        assert "retry" in tokens
+
+    def test_stemming_ed_suffix(self):
+        # "failed" -> strip "ed" -> "fail" (len=6 > 4)
+        tokens = tokenize("failed")
+        assert "fail" in tokens
+
+    def test_stemming_ies_suffix(self):
+        # "retries" -> strip "ies" + "y" -> "retry" (len=7 > 4)
+        tokens = tokenize("retries")
+        assert "retry" in tokens
+
+    def test_stemming_s_suffix(self):
+        # "failures" -> strip "s" -> "failure" (len=8 > 3)
+        tokens = tokenize("failures")
+        assert "failure" in tokens
+
+    def test_short_token_not_stemmed_for_s(self):
+        # "as" is a stopword, but "iss" (len=3) should not get the -s strip
+        # "bus" (len=3) should NOT have the s stripped (len > 3 required)
+        tokens = tokenize("bus")
+        assert "bus" in tokens
+        assert "bu" not in tokens
+
+    def test_case_insensitive(self):
+        assert tokenize("BACKOFF") == tokenize("backoff")
+
+    def test_numbers_included(self):
+        tokens = tokenize("retry 3 times")
+        assert "3" in tokens
+
+    def test_special_chars_excluded(self):
+        tokens = tokenize("hello-world foo@bar.com")
+        assert "hello" in tokens
+        assert "world" in tokens
+        assert "foo" in tokens
+        assert "bar" in tokens
+        assert "-" not in tokens
+        assert "@" not in tokens
+
+    def test_token_counts_returns_counter(self):
+        counts = token_counts("backoff backoff jitter")
+        assert counts["backoff"] == 2
+        assert counts["jitter"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Section 2: BowEmbedder
+# ---------------------------------------------------------------------------
+
+class TestBowEmbedder:
+    def test_embed_returns_dict(self):
+        embedder = BowEmbedder()
+        vec = embedder.embed("exponential backoff jitter")
+        assert isinstance(vec, dict)
+        assert all(isinstance(v, float) for v in vec.values())
+
+    def test_empty_string_returns_empty_dict(self):
+        embedder = BowEmbedder()
+        vec = embedder.embed("")
+        assert vec == {}
+
+    def test_stopword_only_string_returns_empty_dict(self):
+        embedder = BowEmbedder()
+        vec = embedder.embed("a the and or")
+        assert vec == {}
+
+    def test_same_text_same_vector(self):
+        embedder = BowEmbedder()
+        assert embedder.embed("backoff jitter") == embedder.embed("backoff jitter")
+
+
+# ---------------------------------------------------------------------------
+# Section 3: cosine_similarity_vectors edge cases
+# ---------------------------------------------------------------------------
+
+class TestCosineSimilarityVectors:
+    def test_identical_sparse_vectors_score_one(self):
+        vec = {"a": 1.0, "b": 2.0}
+        assert cosine_similarity_vectors(vec, vec) == pytest.approx(1.0)
+
+    def test_orthogonal_sparse_vectors_score_zero(self):
+        left = {"a": 1.0}
+        right = {"b": 1.0}
+        assert cosine_similarity_vectors(left, right) == 0.0
+
+    def test_empty_sparse_vector_returns_zero(self):
+        assert cosine_similarity_vectors({}, {"a": 1.0}) == 0.0
+        assert cosine_similarity_vectors({"a": 1.0}, {}) == 0.0
+
+    def test_empty_dense_vectors_return_zero(self):
+        assert cosine_similarity_vectors((), ()) == 0.0
+
+    def test_dense_vectors_different_length_raises(self):
+        with pytest.raises(ValueError, match="dimensionality"):
+            cosine_similarity_vectors((1.0, 0.0), (1.0, 0.0, 0.0))
+
+    def test_mixed_types_raises(self):
+        with pytest.raises(TypeError):
+            cosine_similarity_vectors({"a": 1.0}, (1.0, 0.0))
+
+    def test_identical_dense_vectors_score_one(self):
+        vec = (1.0, 2.0, 3.0)
+        assert cosine_similarity_vectors(vec, vec) == pytest.approx(1.0)
+
+    def test_cosine_dense_known_value(self):
+        # (1,0) · (0,1) = 0
+        assert cosine_similarity_vectors((1.0, 0.0), (0.0, 1.0)) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Section 4: centroid edge cases
+# ---------------------------------------------------------------------------
+
+class TestCentroid:
+    def test_single_sparse_vector_returns_itself(self):
+        vec = {"a": 2.0, "b": 4.0}
+        c = centroid([vec])
+        assert c == {"a": 2.0, "b": 4.0}
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="At least one vector"):
+            centroid([])
+
+    def test_mixed_sparse_dense_raises(self):
+        with pytest.raises(TypeError):
+            centroid([{"a": 1.0}, (1.0, 0.0)])
+
+    def test_dense_vectors_different_lengths_raises(self):
+        with pytest.raises(ValueError, match="dimensionality"):
+            centroid([(1.0, 0.0), (1.0, 0.0, 0.0)])
+
+    def test_sparse_centroid_averages_correctly(self):
+        c = centroid([{"a": 2.0}, {"a": 4.0}])
+        assert c == {"a": 3.0}
+
+
+# ---------------------------------------------------------------------------
+# Section 5: keyword_overlap edge cases
+# ---------------------------------------------------------------------------
+
+class TestKeywordOverlap:
+    def test_empty_goal_returns_zero(self):
+        assert keyword_overlap("some candidate text", "") == 0.0
+
+    def test_empty_candidate_returns_zero(self):
+        assert keyword_overlap("", "backoff retry jitter") == 0.0
+
+    def test_both_empty_returns_zero(self):
+        assert keyword_overlap("", "") == 0.0
+
+    def test_perfect_overlap_returns_one(self):
+        goal = "backoff"
+        candidate = "backoff"
+        score = keyword_overlap(candidate, goal)
+        assert score == pytest.approx(1.0)
+
+    def test_no_overlap_returns_zero(self):
+        score = keyword_overlap("completely different text", "backoff jitter retry")
+        assert score == 0.0
+
+    def test_score_in_zero_one_range(self):
+        score = keyword_overlap("exponential backoff with jitter and retries", "retry backoff jitter")
+        assert 0.0 <= score <= 1.0
+
+    def test_stopword_goal_returns_zero(self):
+        # "the a and" are all stopwords, tokenize strips them -> empty set
+        score = keyword_overlap("some candidate", "the a and")
+        assert score == 0.0
+
+    def test_mechanism_terms_weighted_higher(self):
+        # A single mechanism match beats multiple generic matches
+        goal = "retry backoff jitter"  # mechanism terms
+        mech_candidate = "retry"
+        gen_candidate = "review plan select new note"  # generic terms
+        assert keyword_overlap(mech_candidate, goal) > keyword_overlap(gen_candidate, goal)
+
+    def test_goal_term_weight_high_for_action_mechanism(self):
+        for term in ["backoff", "jitter", "retry"]:
+            assert goal_term_weight(term) == 4.0
+
+    def test_goal_term_weight_low_for_generic(self):
+        for term in ["plan", "review", "note", "summary"]:
+            assert goal_term_weight(term) == 0.25
+
+    def test_goal_term_weight_default_for_unknown(self):
+        assert goal_term_weight("uniqueterm12345") == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Section 6: surprise_score edge cases
+# ---------------------------------------------------------------------------
+
+class TestSurpriseScore:
+    def test_empty_context_returns_one(self):
+        assert surprise_score("any text", []) == 1.0
+
+    def test_blank_context_items_ignored(self):
+        # Blank items stripped in surprise_score
+        assert surprise_score("any text", ["", "   "]) == 1.0
+
+    def test_identical_candidate_and_context_returns_zero(self):
+        text = "retry with exponential backoff and jitter"
+        score = surprise_score(text, [text])
+        assert score == pytest.approx(0.0, abs=1e-9)
+
+    def test_score_in_zero_one_range_with_various_inputs(self):
+        contexts = [
+            "The client retries with fixed delay.",
+            "Use timeout on each request.",
+        ]
+        score = surprise_score("Exponential backoff with jitter.", contexts)
+        assert 0.0 <= score <= 1.0
+
+    def test_single_item_context_gives_lower_score_for_similar_candidate(self):
+        context = ["Retry with exponential backoff."]
+        similar = "Exponential backoff retry strategy."
+        different = "Database schema migration plan."
+        sim_score = surprise_score(similar, context)
+        diff_score = surprise_score(different, context)
+        assert diff_score > sim_score
+
+
+# ---------------------------------------------------------------------------
+# Section 7: psi_0 invariants
+# ---------------------------------------------------------------------------
+
+class TestPsi0:
+    def test_score_equals_value_times_surprise(self):
+        score, value, surprise = psi_0(
+            "exponential backoff handles rate limits",
+            "retry with exponential backoff and jitter",
+            ["The client uses fixed delay retries."],
+        )
+        assert score == pytest.approx(value * surprise, rel=1e-6)
+
+    def test_score_is_zero_when_context_identical_to_candidate(self):
+        text = "exponential backoff with jitter"
+        score, value, surprise = psi_0(text, "retry logic backoff", [text])
+        assert score == pytest.approx(0.0, abs=1e-9)
+
+    def test_score_is_zero_when_no_goal_overlap(self):
+        score, value, surprise = psi_0(
+            "completely unrelated note",
+            "exponential backoff jitter retry",
+            [],
+        )
+        assert score == 0.0
+
+    def test_high_relevance_novel_candidate_beats_redundant(self):
+        goal = "retry with exponential backoff and jitter"
+        context = ["The client retries with fixed delay."]
+        novel_relevant = "Exponential backoff with jitter handles rate limits."
+        redundant = "The client retries with fixed delay."
+
+        score_novel, _, _ = psi_0(novel_relevant, goal, context)
+        score_redundant, _, _ = psi_0(redundant, goal, context)
+        assert score_novel > score_redundant
+
+    def test_all_components_in_zero_one_range(self):
+        for candidate_text, context in [
+            ("backoff jitter retry", ["fixed delay retry"]),
+            ("", ["context"]),
+            ("novel text", []),
+        ]:
+            score, value, surprise = psi_0(candidate_text, "retry backoff", context)
+            assert 0.0 <= score <= 1.0
+            assert 0.0 <= value <= 1.0
+            assert 0.0 <= surprise <= 1.0
+
+    def test_empty_candidate_scores_zero(self):
+        score, value, surprise = psi_0("", "retry with backoff", ["some context"])
+        assert score == 0.0
+        assert value == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Section 8: Planning bonus logic
+# ---------------------------------------------------------------------------
+
+class TestPlanningBonus:
+    def test_planning_shaped_goal_detected(self):
+        assert _goal_is_planning_shaped("Plan the roadmap migration")
+        assert _goal_is_planning_shaped("Create a rollout timeline")
+        assert not _goal_is_planning_shaped("Retry logic with exponential backoff")
+
+    def test_plan_structure_score_zero_for_non_planning_goal(self):
+        score = _plan_structure_score("First phase then milestone", "Improve API retry logic")
+        assert score == 0.0
+
+    def test_plan_structure_score_bucketed_by_cue_type(self):
+        # Max 4 buckets: sequencing, dependency, risk, relation
+        candidate = "First phase. Depends on prerequisite. Risk of rollback. Missing from draft."
+        goal = "Plan the migration roadmap"
+        score = _plan_structure_score(candidate, goal)
+        assert score == pytest.approx(4 / 4)
+
+    def test_plan_structure_score_partial_buckets(self):
+        # Only sequencing cue
+        candidate = "First step then next phase"
+        goal = "Plan the roadmap rollout"
+        score = _plan_structure_score(candidate, goal)
+        assert score == pytest.approx(1 / 4)
+
+    def test_value_with_plan_bonus_clamps_at_one(self):
+        # Manually construct a case where v_base + bonus could exceed 1.0
+        # v_base = 1.0, bonus = PLAN_BONUS_ALPHA * 1.0
+        # Actually hard to achieve v_base=1.0 in practice, but we can test clamp logic
+        # by checking that value never exceeds 1.0
+        goal = "Plan the roadmap migration phase rollout"
+        # Dense cue-rich candidate likely to get near-max v and near-max plan score
+        candidate = (
+            "First phase of rollout migration roadmap. "
+            "Depends on prerequisite. Risk rollback milestone timeline. Missing from plan."
+        )
+        v_prime, v_base = _value_with_plan_bonus(candidate, goal)
+        assert v_prime <= 1.0
+        assert v_prime >= v_base
+
+    def test_plan_bonus_not_applied_when_v_base_zero(self):
+        goal = "Plan the rollout migration roadmap"
+        # Candidate has no goal keyword overlap
+        candidate = "First step then after depends prerequisite risk"
+        v_prime, v_base = _value_with_plan_bonus(candidate, goal)
+        assert v_base == 0.0
+        assert v_prime == 0.0  # bonus is gated on v_base > 0
+
+
+# ---------------------------------------------------------------------------
+# Section 9: rank_candidates and fit_to_budget
+# ---------------------------------------------------------------------------
+
+class TestRankAndBudget:
+    def _make_candidates(self, n: int) -> list[Candidate]:
+        return [Candidate(id=f"c{i}", text=f"candidate {i} text", source="test") for i in range(n)]
+
+    def test_empty_candidates_returns_empty_ranked(self):
+        result = rank_candidates([], goal="retry backoff", current_context=[])
+        assert result == []
+
+    def test_single_candidate_returns_single_ranked(self):
+        candidates = [Candidate(id="one", text="exponential backoff retry", source="test")]
+        ranked = rank_candidates(candidates, goal="retry backoff jitter", current_context=[])
+        assert len(ranked) == 1
+
+    def test_all_identical_candidates_ranked_by_id_tiebreak(self):
+        # All identical text -> same score; fallback sort should be deterministic
+        candidates = [
+            Candidate(id="b", text="backoff jitter retry", source="test"),
+            Candidate(id="a", text="backoff jitter retry", source="test"),
+        ]
+        ranked = rank_candidates(candidates, goal="backoff jitter", current_context=[])
+        # Same score bucket and value -> sort by id (alphabetical)
+        assert ranked[0].candidate.id == "a"
+        assert ranked[1].candidate.id == "b"
+
+    def test_fit_to_budget_empty_input_returns_empty(self):
+        assert fit_to_budget([], max_tokens=100) == []
+
+    def test_fit_to_budget_item_too_large_skipped(self):
+        large = Candidate(id="large", text="one two three four five six seven eight nine ten", source="test")
+        ranked = rank_candidates([large], goal="one two three", current_context=[], embedder=None)
+        selected = fit_to_budget(ranked, max_tokens=5)
+        assert selected == []
+
+    def test_fit_to_budget_exactly_at_limit(self):
+        candidate = Candidate(id="c", text="one two three", source="test")  # 3 tokens
+        ranked = rank_candidates([candidate], goal="one", current_context=[])
+        selected = fit_to_budget(ranked, max_tokens=3)
+        assert len(selected) == 1
+
+    def test_fit_to_budget_zero_max_tokens(self):
+        candidate = Candidate(id="c", text="one", source="test")
+        ranked = rank_candidates([candidate], goal="one", current_context=[])
+        selected = fit_to_budget(ranked, max_tokens=0)
+        assert selected == []
+
+    def test_near_tie_epsilon_boundary(self):
+        """Scores within NEAR_TIE_EPSILON should fall in same bucket; outside should not."""
+        # Two candidates where scores are just within epsilon
+        candidates = [
+            Candidate(id="low_v", text="low_v", source="a"),
+            Candidate(id="high_v", text="high_v", source="b"),
+        ]
+        # scores: 0.005 vs 0.009 — within epsilon 0.01, same bucket
+        scores_map = {
+            "low_v": (0.005, 0.10, 0.05),
+            "high_v": (0.009, 0.30, 0.03),
+        }
+
+        def scorer(text, goal, ctx, emb):
+            return scores_map[text]
+
+        ranked = rank_candidates(candidates, goal="g", current_context=[], scorer=scorer)
+        # Same bucket -> higher value (high_v, 0.30) should rank first
+        assert ranked[0].candidate.id == "high_v"
+
+
+# ---------------------------------------------------------------------------
+# Section 10: select_context and PsiLoop integration
+# ---------------------------------------------------------------------------
+
+class TestSelectContext:
+    def test_select_context_returns_selection_result(self):
+        candidates = [
+            Candidate(id="a", text="exponential backoff jitter retry", source="test"),
+            Candidate(id="b", text="fixed delay retry", source="test"),
+        ]
+        result = select_context(
+            candidates=candidates,
+            goal="retry with exponential backoff and jitter",
+            current_context=["The client uses fixed delay."],
+            max_tokens=20,
+        )
+        assert isinstance(result, SelectionResult)
+        assert result.max_tokens == 20
+        assert len(result.ranked) == 2
+
+    def test_psiloop_requires_source_or_candidates(self):
+        loop = PsiLoop()  # no source
+        with pytest.raises(ValueError, match="candidates or a configured source"):
+            loop.select(goal="test", current_context=[], max_tokens=50)
+
+    def test_psiloop_with_candidates_directly(self):
+        candidates = [
+            Candidate(id="a", text="backoff jitter retry rate limits", source="test"),
+            Candidate(id="b", text="fixed delay retry", source="test"),
+        ]
+        loop = PsiLoop()
+        result = loop.select(
+            goal="exponential backoff jitter retry",
+            current_context=["Fixed delay retry is the current approach."],
+            max_tokens=50,
+            candidates=candidates,
+        )
+        assert result.ranked[0].candidate.id == "a"
+
+    def test_psiloop_fetch_k_limits_candidates_from_source(self):
+        source = FixtureSource(Path(__file__).parent / "fixtures" / "sample_tasks.json")
+        loop = PsiLoop(source=source)
+        task = source.get_task("retry_backoff")
+
+        result = loop.select(
+            goal=task.goal,
+            current_context=task.current_context,
+            max_tokens=task.max_tokens,
+            task_id=task.id,
+            fetch_k=1,
+        )
+        # Only 1 candidate fetched
+        assert len(result.ranked) == 1
+
+    def test_select_context_empty_candidates(self):
+        result = select_context(
+            candidates=[],
+            goal="retry with backoff",
+            current_context=[],
+            max_tokens=100,
+        )
+        assert result.ranked == []
+        assert result.selected == []
+
+
+# ---------------------------------------------------------------------------
+# Section 11: Baseline behavior
+# ---------------------------------------------------------------------------
+
+class TestBaseline:
+    def test_baseline_ignores_context(self):
+        """Baseline score should be identical whether context is empty or populated."""
+        candidates = [
+            Candidate(id="a", text="backoff jitter retry", source="test"),
+        ]
+        result_no_ctx = select_context_baseline(
+            candidates=candidates,
+            goal="retry backoff jitter",
+            max_tokens=50,
+        )
+        result_with_ctx = select_context_baseline(
+            candidates=candidates,
+            goal="retry backoff jitter",
+            max_tokens=50,
+        )
+        assert result_no_ctx.ranked[0].score == result_with_ctx.ranked[0].score
+
+    def test_baseline_redundant_candidate_scores_high(self):
+        """Baseline picks whatever overlaps most with goal, even if redundant with context."""
+        goal = "retry with fixed delay for transient failures"
+        context = ["The client already uses fixed delay retries for transient failures."]
+        candidates = [
+            Candidate(id="redundant", text="retry with fixed delay for transient failures", source="test"),
+            Candidate(id="novel", text="exponential backoff with jitter avoids thundering herd", source="test"),
+        ]
+        result = select_context_baseline(candidates=candidates, goal=goal, max_tokens=50)
+        assert result.ranked[0].candidate.id == "redundant"
+
+
+# ---------------------------------------------------------------------------
+# Section 12: FixtureSource edge cases
+# ---------------------------------------------------------------------------
+
+class TestFixtureSource:
+    def test_bundled_source_returns_tasks(self):
+        source = FixtureSource()
+        tasks = source.tasks()
+        assert len(tasks) >= 1
+
+    def test_missing_task_id_raises(self):
+        source = FixtureSource(Path(__file__).parent / "fixtures" / "sample_tasks.json")
+        with pytest.raises(ValueError, match="not found"):
+            source.get_task("nonexistent_task_id")
+
+    def test_fetch_no_limit_returns_all(self):
+        source = FixtureSource(Path(__file__).parent / "fixtures" / "sample_tasks.json")
+        candidates = source.fetch(SourceRequest(goal="test", task_id="retry_backoff"))
+        assert len(candidates) == 3
+
+    def test_fetch_limit_zero_returns_empty(self):
+        source = FixtureSource(Path(__file__).parent / "fixtures" / "sample_tasks.json")
+        candidates = source.fetch(SourceRequest(goal="test", task_id="retry_backoff", limit=0))
+        assert candidates == []
+
+    def test_default_task_is_first(self):
+        source = FixtureSource(Path(__file__).parent / "fixtures" / "sample_tasks.json")
+        task = source.get_task(None)
+        assert task.id == "retry_backoff"
+
+
+# ---------------------------------------------------------------------------
+# Section 13: README example — exact demo scenario
+# ---------------------------------------------------------------------------
+
+class TestReadmeDemo:
+    """Test the exact scenario described in the README."""
+
+    def test_psi0_prefers_novel_backoff_candidate(self):
+        """The README says: Psi0 prefers the novel exponential backoff note."""
+        source = FixtureSource()
+        task = source.get_task("retry_backoff")
+        loop = PsiLoop(source=source)
+
+        result = loop.select(
+            goal=task.goal,
+            current_context=task.current_context,
+            max_tokens=task.max_tokens,
+            candidates=task.candidates,
+        )
+        assert result.ranked[0].candidate.id == "novel_backoff_jitter"
+
+    def test_baseline_prefers_redundant_candidate(self):
+        """The README says: the baseline prefers the redundant fixed-delay note."""
+        source = FixtureSource()
+        task = source.get_task("retry_backoff")
+
+        result = select_context_baseline(
+            candidates=task.candidates,
+            goal=task.goal,
+            max_tokens=task.max_tokens,
+        )
+        assert result.ranked[0].candidate.id == "redundant_fixed_delay"
+
+    def test_cli_list_tasks_includes_retry_backoff(self, monkeypatch, capsys):
+        from psi_loop import cli
+        monkeypatch.setattr("sys.argv", ["psi-loop", "--list-tasks"])
+        cli.main()
+        output = capsys.readouterr().out
+        assert "retry_backoff" in output
+
+
+# ---------------------------------------------------------------------------
+# Section 14: Mathematical invariants and soundness checks
+# ---------------------------------------------------------------------------
+
+class TestMathInvariants:
+    def test_psi0_is_multiplicative(self):
+        """Psi0 = V * H should exactly equal returned score."""
+        for candidate_text, goal, context in [
+            ("backoff jitter retry rate limit", "retry exponential backoff", ["fixed delay"]),
+            ("schema migration timeline rollout", "plan migration roadmap", []),
+            ("", "retry backoff", ["context item"]),
+        ]:
+            score, value, surprise = psi_0(candidate_text, goal, context)
+            assert score == pytest.approx(value * surprise, rel=1e-9, abs=1e-12)
+
+    def test_surprise_decreases_as_context_grows_similar(self):
+        """Adding more context items identical to candidate should push surprise toward 0."""
+        candidate = "exponential backoff with jitter"
+        base_surprise = surprise_score(candidate, [candidate])
+        more_surprise = surprise_score(candidate, [candidate, candidate, candidate])
+        # All identical: centroid = same, surprise should stay at ~0
+        assert base_surprise == pytest.approx(0.0, abs=1e-9)
+        assert more_surprise == pytest.approx(0.0, abs=1e-9)
+
+    def test_psi0_score_bounded(self):
+        """Psi0 score is in [0,1] since both V and H are clamped to [0,1]."""
+        for text, goal, ctx in [
+            ("backoff jitter retry", "retry backoff jitter exponential", []),
+            ("aaa bbb ccc", "retry backoff", ["jitter exponential"]),
+        ]:
+            score, v, h = psi_0(text, goal, ctx)
+            assert 0.0 <= score <= 1.0
+            assert 0.0 <= v <= 1.0
+            assert 0.0 <= h <= 1.0
+
+    def test_cosine_similarity_symmetric(self):
+        """cosine_similarity_vectors(a, b) == cosine_similarity_vectors(b, a)."""
+        left = {"backoff": 2.0, "jitter": 1.0}
+        right = {"backoff": 1.0, "retry": 3.0}
+        assert cosine_similarity_vectors(left, right) == pytest.approx(
+            cosine_similarity_vectors(right, left)
+        )
+
+    def test_plan_bonus_alpha_less_than_one(self):
+        """PLAN_BONUS_ALPHA should be small enough that it can't make a zero-overlap item positive."""
+        assert PLAN_BONUS_ALPHA < 1.0
+        assert PLAN_BONUS_ALPHA > 0.0
+
+    def test_near_tie_epsilon_is_small(self):
+        """NEAR_TIE_EPSILON should be meaningfully small relative to the [0,1] score range."""
+        assert NEAR_TIE_EPSILON < 0.05
+        assert NEAR_TIE_EPSILON > 0.0
+
+    def test_baseline_score_surprise_is_always_zero(self):
+        """baseline_score() always returns surprise=0.0."""
+        from psi_loop.baseline import baseline_score
+        for text, goal in [
+            ("backoff jitter", "retry backoff"),
+            ("", "retry backoff"),
+            ("completely different", "retry backoff jitter"),
+        ]:
+            _, _, surprise = baseline_score(text, goal, ["some context"])
+            assert surprise == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Section 15: Large / stress inputs
+# ---------------------------------------------------------------------------
+
+class TestLargeInputs:
+    def test_many_candidates_all_scored(self):
+        candidates = [
+            Candidate(id=f"c{i}", text=f"retry backoff jitter candidate {i}", source="test")
+            for i in range(100)
+        ]
+        result = select_context(
+            candidates=candidates,
+            goal="retry exponential backoff",
+            current_context=[],
+            max_tokens=1000,
+        )
+        assert len(result.ranked) == 100
+
+    def test_very_long_text_does_not_crash(self):
+        long_text = "retry " * 1000
+        score, value, surprise = psi_0(long_text, "retry backoff jitter", [])
+        assert 0.0 <= score <= 1.0
+
+    def test_very_long_goal_does_not_crash(self):
+        long_goal = "retry " * 500 + "backoff jitter"
+        score, value, surprise = psi_0("exponential backoff with jitter", long_goal, [])
+        assert 0.0 <= score <= 1.0
+
+    def test_large_context_does_not_crash(self):
+        large_context = [f"context item {i} with retry and backoff" for i in range(200)]
+        score = surprise_score("novel exponential jitter", large_context)
+        assert 0.0 <= score <= 1.0
+
+    def test_single_candidate_selected_when_fits(self):
+        candidate = Candidate(id="only", text="backoff jitter retry", source="test")
+        result = select_context(
+            candidates=[candidate],
+            goal="retry backoff jitter",
+            current_context=[],
+            max_tokens=100,
+        )
+        assert len(result.selected) == 1
+        assert result.selected[0].candidate.id == "only"
+
+    def test_no_candidate_fits_budget_selected_is_empty(self):
+        big_candidates = [
+            Candidate(id=f"big{i}", text="one " * 50, source="test")
+            for i in range(5)
+        ]
+        result = select_context(
+            candidates=big_candidates,
+            goal="retry backoff",
+            current_context=[],
+            max_tokens=5,
+        )
+        assert result.selected == []

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -418,3 +418,33 @@ class TestBotReviewFixes:
                     assert trace_item.reason == "selected", (
                         f"{selector.name}: {cid} is in selected but trace says {trace_item.reason}"
                     )
+
+    # --- Issue 3 (P2): iterative remainder filtered by identity, not id ---
+
+    def test_iterative_duplicate_id_candidates_both_considered(self):
+        """Two distinct Candidate objects that share an id must both be eligible
+        for selection — only the picked object should be removed from remaining."""
+        # Create two candidates with the same id but different text/source.
+        c1 = Candidate(id="dup", text="retry backoff jitter", source="source-a")
+        c2 = Candidate(id="dup", text="dead-letter queue overflow", source="source-b")
+        goal = "retry queue resilience"
+
+        result = select_context([c1, c2], goal, [], max_tokens=200, iterative=True)
+        selected_texts = {sc.candidate.text for sc in result.selected}
+
+        # Both must have been considered — the second should appear in selected
+        # because it covers different vocabulary (queue) the first doesn't.
+        assert len(result.selected) == 2, (
+            f"Expected both candidates selected, got: {selected_texts}"
+        )
+
+    def test_iterative_unique_candidates_unaffected_by_identity_filter(self):
+        """Standard case (all unique ids) must behave identically before and after
+        the id→identity filter change."""
+        candidates = [
+            make_candidate("A", "retry backoff jitter"),
+            make_candidate("B", "dead-letter queue overflow"),
+            make_candidate("C", "idempotency key deduplication"),
+        ]
+        result = select_context(candidates, "retry queue resilience", [], max_tokens=200, iterative=True)
+        assert {sc.candidate.id for sc in result.selected} == {"A", "B", "C"}

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,0 +1,312 @@
+"""Tests for the four psi-loop fixes.
+
+Fix 1: forensics exposed in __all__
+Fix 2: BowEmbedder L2-normalized
+Fix 3: near-tie bucketing comment (behaviour unchanged — no new tests needed)
+Fix 4: iterative selection as default
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from psi_loop import (
+    BowEmbedder,
+    Candidate,
+    PsiLoop,
+    build_task_forensics,
+    render_task_forensics,
+    select_context,
+    surprise_score,
+)
+from psi_loop.embedders import centroid, cosine_similarity_vectors
+from psi_loop.pipeline import fit_to_budget, rank_candidates, select_with_scorer
+from psi_loop.scoring import psi_0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_candidate(id: str, text: str) -> Candidate:
+    return Candidate(id=id, text=text, source="test")
+
+
+def l2_norm(vec: dict) -> float:
+    return math.sqrt(sum(v * v for v in vec.values()))
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: forensics in __all__
+# ---------------------------------------------------------------------------
+
+class TestForensicsPublicAPI:
+    def test_build_task_forensics_importable_from_top_level(self):
+        # If this import line at the top of the file didn't explode, this passes.
+        assert callable(build_task_forensics)
+
+    def test_render_task_forensics_importable_from_top_level(self):
+        assert callable(render_task_forensics)
+
+    def test_both_names_in_psi_loop_all(self):
+        import psi_loop
+        assert "build_task_forensics" in psi_loop.__all__
+        assert "render_task_forensics" in psi_loop.__all__
+
+    def test_forensics_roundtrip_with_fixture_source(self):
+        """build_task_forensics via public import returns a non-empty report."""
+        from psi_loop.models import TaskDefinition
+        task_def = TaskDefinition(
+            id="fix1-roundtrip",
+            goal="design retry with backoff",
+            current_context=["We already discussed timeouts."],
+            max_tokens=200,
+            candidates=[
+                Candidate(id="c1", text="Use exponential backoff with jitter on retry.", source="t"),
+                Candidate(id="c2", text="Timeouts should be aggressive.", source="t"),
+            ],
+        )
+        forensics = build_task_forensics(task_def)
+        assert forensics.task_id == "fix1-roundtrip"
+        assert len(forensics.psi0.ranked) == 2
+        rendered = render_task_forensics(forensics, top_k=2)
+        assert "fix1-roundtrip" in rendered
+        assert "Diagnosis" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: BowEmbedder L2-normalized
+# ---------------------------------------------------------------------------
+
+class TestBowEmbedderL2Normalization:
+    def test_single_token_has_unit_norm(self):
+        vec = BowEmbedder().embed("retry")
+        assert pytest.approx(l2_norm(vec), abs=1e-9) == 1.0
+
+    def test_multi_token_has_unit_norm(self):
+        vec = BowEmbedder().embed("retry backoff jitter queue migration")
+        assert pytest.approx(l2_norm(vec), abs=1e-9) == 1.0
+
+    def test_empty_string_returns_empty_dict(self):
+        vec = BowEmbedder().embed("")
+        assert vec == {}
+
+    def test_stopword_only_returns_empty_dict(self):
+        vec = BowEmbedder().embed("the a and is of")
+        assert vec == {}
+
+    def test_embedding_is_deterministic(self):
+        e = BowEmbedder()
+        assert e.embed("retry with backoff") == e.embed("retry with backoff")
+
+    def test_repeated_token_still_unit_norm(self):
+        # "retry retry retry" — raw counts {retry: 3}, norm = 3, normalised = {retry: 1.0}
+        vec = BowEmbedder().embed("retry retry retry")
+        assert pytest.approx(l2_norm(vec), abs=1e-9) == 1.0
+        assert pytest.approx(vec["retry"], abs=1e-9) == 1.0
+        assert len(vec) == 1
+
+    def test_no_length_bias_in_centroid(self):
+        """A 2-token chunk and a 20-token chunk should contribute equally to the centroid."""
+        emb = BowEmbedder()
+        short = emb.embed("retry backoff")
+        long_text = " ".join(["retry", "backoff"] + [f"word{i}" for i in range(18)])
+        long = emb.embed(long_text)
+
+        # Both vectors are unit-length; their cosine similarity with each other
+        # is determined by shared content, not length.  The centroid norm is
+        # bounded by 1 (it can only decrease due to cancellation).
+        c = centroid([short, long])
+        assert l2_norm(c) <= 1.0 + 1e-9
+
+    def test_identical_candidates_have_cosine_similarity_one(self):
+        emb = BowEmbedder()
+        v = emb.embed("retry with exponential backoff")
+        assert pytest.approx(cosine_similarity_vectors(v, v), abs=1e-9) == 1.0
+
+    def test_disjoint_candidates_have_zero_cosine_similarity(self):
+        emb = BowEmbedder()
+        v1 = emb.embed("retry backoff")
+        v2 = emb.embed("queue migration")
+        assert pytest.approx(cosine_similarity_vectors(v1, v2), abs=1e-9) == 0.0
+
+    def test_surprise_identical_candidate_in_context_is_zero(self):
+        text = "Use exponential backoff on retry"
+        h = surprise_score(text, [text])
+        assert pytest.approx(h, abs=1e-9) == 0.0
+
+    def test_surprise_novel_candidate_against_disjoint_context_is_one(self):
+        h = surprise_score("queue dead-letter migration", ["retry backoff jitter"])
+        assert pytest.approx(h, abs=1e-9) == 1.0
+
+    def test_surprise_range_invariant(self):
+        h = surprise_score("retry backoff queue", ["retry", "backoff", "queue migration"])
+        assert 0.0 <= h <= 1.0
+
+    def test_long_context_does_not_dominate_surprise(self):
+        """With normalisation, adding many identical context items shouldn't make
+        the centroid explode — the centroid of unit vectors is bounded in norm."""
+        long_item = "retry backoff " + " ".join(f"extra{i}" for i in range(50))
+        short_item = "retry backoff"
+        h_short_ctx = surprise_score("queue migration", [short_item])
+        h_long_ctx  = surprise_score("queue migration", [long_item])
+        # Both contexts are about "retry backoff" (+ noise in long case).
+        # Neither should make surprise for a completely disjoint candidate go below 0.
+        assert h_short_ctx >= 0.0
+        assert h_long_ctx  >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: iterative selection (default behaviour)
+# ---------------------------------------------------------------------------
+
+class TestIterativeSelection:
+    """iterative=True is the new default for select_context and PsiLoop.select."""
+
+    def _redundant_set(self):
+        """A and B say nearly the same thing; C is genuinely novel."""
+        return [
+            make_candidate("A", "Use exponential backoff with jitter on retry"),
+            make_candidate("B", "Retry using exponential backoff and add jitter between attempts"),
+            make_candidate("C", "Add a dead-letter queue for messages that exhaust retries"),
+        ]
+
+    def test_iterative_default_suppresses_redundant_second_pick(self):
+        """After A is selected, B should be penalised and C preferred."""
+        candidates = self._redundant_set()
+        result = select_context(candidates, "design retry strategy with backoff", [], max_tokens=60)
+        ids = [sc.candidate.id for sc in result.selected]
+        # A should always be first; C should beat B for second slot.
+        assert ids[0] == "A"
+        assert "C" in ids
+        assert ids.index("C") < ids.index("B") if "B" in ids else True
+
+    def test_non_iterative_selects_both_redundant_candidates(self):
+        """With iterative=False, A and B both score equally against empty context."""
+        candidates = self._redundant_set()
+        result = select_context(
+            candidates, "design retry strategy with backoff", [], max_tokens=60, iterative=False
+        )
+        ids = [sc.candidate.id for sc in result.selected]
+        # Both A and B score the same against empty context — both get selected.
+        assert "A" in ids
+        assert "B" in ids
+
+    def test_iterative_flag_false_matches_original_fit_to_budget(self):
+        """iterative=False must produce the same result as the legacy fit_to_budget path."""
+        candidates = self._redundant_set()
+        goal = "design retry strategy with backoff"
+        result_flag = select_context(candidates, goal, [], max_tokens=60, iterative=False)
+        ranked = rank_candidates(candidates, goal, [])
+        legacy_selected = fit_to_budget(ranked, max_tokens=60)
+        assert [sc.candidate.id for sc in result_flag.selected] == [sc.candidate.id for sc in legacy_selected]
+
+    def test_psiloop_select_iterative_default(self):
+        loop = PsiLoop()
+        candidates = self._redundant_set()
+        result = loop.select("design retry strategy with backoff", [], max_tokens=60, candidates=candidates)
+        ids = [sc.candidate.id for sc in result.selected]
+        assert ids[0] == "A"
+        assert "C" in ids
+
+    def test_psiloop_select_iterative_false(self):
+        loop = PsiLoop()
+        candidates = self._redundant_set()
+        result = loop.select(
+            "design retry strategy with backoff", [], max_tokens=60,
+            candidates=candidates, iterative=False
+        )
+        ids = [sc.candidate.id for sc in result.selected]
+        assert "A" in ids and "B" in ids
+
+    def test_iterative_single_candidate_same_as_non_iterative(self):
+        c = [make_candidate("only", "retry with backoff")]
+        r_iter = select_context(c, "retry backoff", [], max_tokens=20, iterative=True)
+        r_flat = select_context(c, "retry backoff", [], max_tokens=20, iterative=False)
+        assert [sc.candidate.id for sc in r_iter.selected] == [sc.candidate.id for sc in r_flat.selected]
+
+    def test_iterative_empty_candidates_returns_empty(self):
+        result = select_context([], "retry backoff", [], max_tokens=100, iterative=True)
+        assert result.selected == []
+        assert result.ranked == []
+
+    def test_iterative_nothing_fits_budget_returns_empty(self):
+        c = [make_candidate("big", "retry " * 200)]
+        result = select_context(c, "retry", [], max_tokens=5, iterative=True)
+        assert result.selected == []
+
+    def test_iterative_all_identical_candidates_selects_one(self):
+        """All three say exactly the same thing — only the first should survive."""
+        text = "Use exponential backoff with jitter"
+        candidates = [make_candidate(f"c{i}", text) for i in range(3)]
+        result = select_context(candidates, "retry backoff", [], max_tokens=100, iterative=True)
+        # After the first pick, surprise for any remaining identical candidate → 0,
+        # so their Psi0 score → 0 and they should not be selected over nothing.
+        # (They may still be selected if budget allows and score > 0 due to floating point,
+        #  but the key invariant is score drops sharply.)
+        selected_ids = [sc.candidate.id for sc in result.selected]
+        # At most one unique-content candidate should dominate.
+        if len(selected_ids) > 1:
+            # If extras are selected, their surprise must be near zero.
+            for sc in result.selected[1:]:
+                assert sc.surprise < 0.05, f"Expected near-zero surprise for redundant pick, got {sc.surprise}"
+
+    def test_iterative_ranked_is_initial_pass_not_final_selected_order(self):
+        """result.ranked always reflects the initial scoring (before iterative updates).
+        It is not reordered by iterative selection — it is for inspection / forensics."""
+        candidates = self._redundant_set()
+        result = select_context(candidates, "design retry strategy with backoff", [], max_tokens=60)
+        # ranked must contain all candidates
+        assert len(result.ranked) == len(candidates)
+
+    def test_iterative_running_context_grows(self):
+        """After N picks the running context has grown — simulate with unique candidates
+        and verify that each pick is genuinely distinct from the last."""
+        candidates = [
+            make_candidate("retry", "exponential backoff retry"),
+            make_candidate("queue", "dead-letter queue overflow"),
+            make_candidate("idempotency", "idempotency key deduplication"),
+        ]
+        result = select_context(candidates, "resilience patterns", [], max_tokens=200, iterative=True)
+        selected_ids = {sc.candidate.id for sc in result.selected}
+        # All three are topically distinct — all three should be selected.
+        assert selected_ids == {"retry", "queue", "idempotency"}
+
+    def test_select_with_scorer_iterative_flag_propagated(self):
+        """select_with_scorer also honours iterative flag."""
+        candidates = self._redundant_set()
+        goal = "design retry strategy with backoff"
+        r_iter = select_with_scorer(candidates, goal, [], 60, psi_0, iterative=True)
+        r_flat = select_with_scorer(candidates, goal, [], 60, psi_0, iterative=False)
+        # iterative suppresses B; non-iterative selects both A and B
+        iter_ids = [sc.candidate.id for sc in r_iter.selected]
+        flat_ids = [sc.candidate.id for sc in r_flat.selected]
+        assert "A" in iter_ids and "A" in flat_ids
+        assert "B" in flat_ids  # non-iterative selects both
+        # iterative may or may not select B but must prefer C
+        if "B" in iter_ids and "C" in iter_ids:
+            assert iter_ids.index("C") < iter_ids.index("B")
+
+    def test_iterative_respects_token_budget_exactly(self):
+        """Total token count of selected items must not exceed max_tokens."""
+        candidates = [make_candidate(f"c{i}", f"retry backoff jitter {'word ' * i}") for i in range(5)]
+        result = select_context(candidates, "retry", [], max_tokens=20, iterative=True)
+        total = sum(sc.token_count for sc in result.selected)
+        assert total <= 20
+
+    def test_iterative_with_existing_context_compounds_suppression(self):
+        """When current_context already covers a topic, related candidates should score
+        lower than candidates on an uncovered topic."""
+        current_context = ["We are already using exponential backoff with jitter on retries."]
+        candidates = [
+            make_candidate("redundant", "Retry uses exponential backoff and jitter"),
+            make_candidate("novel", "Add a dead-letter queue for exhausted retry messages"),
+        ]
+        result = select_context(
+            candidates, "improve retry resilience", current_context, max_tokens=100, iterative=True
+        )
+        ids = [sc.candidate.id for sc in result.selected]
+        # Novel should be ranked above redundant since context already covers backoff.
+        assert ids[0] == "novel"

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -22,7 +22,7 @@ from psi_loop import (
     surprise_score,
 )
 from psi_loop.embedders import centroid, cosine_similarity_vectors
-from psi_loop.pipeline import fit_to_budget, rank_candidates, select_with_scorer
+from psi_loop.pipeline import _near_tie_sort_key, fit_to_budget, rank_candidates, select_with_scorer
 from psi_loop.scoring import psi_0
 
 
@@ -310,3 +310,111 @@ class TestIterativeSelection:
         ids = [sc.candidate.id for sc in result.selected]
         # Novel should be ranked above redundant since context already covers backoff.
         assert ids[0] == "novel"
+
+
+# ---------------------------------------------------------------------------
+# Bot review fixes: near-tie key in iterative rounds + forensics consistency
+# ---------------------------------------------------------------------------
+
+class TestBotReviewFixes:
+    """Covers the two issues flagged by Codex during PR review."""
+
+    # --- Issue 1: near-tie sort key shared between rank_candidates and _select_iterative ---
+
+    def test_near_tie_sort_key_is_module_level(self):
+        """_near_tie_sort_key must be importable so both ranking paths share it."""
+        assert callable(_near_tie_sort_key)
+
+    def test_near_tie_key_buckets_score_not_raw(self):
+        """The key must bucket by NEAR_TIE_EPSILON, not sort by raw score."""
+        from psi_loop.pipeline import NEAR_TIE_EPSILON
+        from psi_loop.models import ScoredCandidate
+        # Two candidates whose scores straddle a bucket boundary by sub-epsilon.
+        # With raw-score sorting the higher-score item always wins regardless of value.
+        # With bucketed sorting they land in the same bucket and the higher-VALUE item wins.
+        low_score_high_value = ScoredCandidate(
+            candidate=make_candidate("hv", "x"), score=0.100, value=0.9, surprise=0.111, token_count=1
+        )
+        high_score_low_value = ScoredCandidate(
+            candidate=make_candidate("lv", "x"), score=0.109, value=0.1, surprise=1.0, token_count=1
+        )
+        # Both fall in the 0.10 bucket (floor(0.100/0.01)*0.01 == floor(0.109/0.01)*0.01 == 0.10).
+        assert _near_tie_sort_key(low_score_high_value) < _near_tie_sort_key(high_score_low_value), (
+            "Higher-value candidate should sort first when scores are in the same bucket"
+        )
+
+    def test_iterative_near_tie_prefers_value_over_sub_epsilon_score_jitter(self):
+        """Within an iterative round, a candidate with higher V should beat one with
+        trivially higher score when both are in the same NEAR_TIE_EPSILON bucket."""
+        # Construct a scenario where, after one pick updates context, two remaining
+        # candidates have scores in the same epsilon bucket but different values.
+        # We do this by pre-seeding context so surprise is roughly equal.
+        shared_context = ["retry backoff strategy"]
+        # Both candidates are about "retry backoff" so surprise is similar.
+        high_value = make_candidate("hv", "retry backoff idempotency queue guardrail migration")
+        low_value  = make_candidate("lv", "retry")
+        goal = "design retry strategy with backoff idempotency"
+
+        result = select_context(
+            [high_value, low_value], goal, shared_context, max_tokens=50, iterative=True
+        )
+        # high_value mentions more goal terms → higher V; it must be picked first.
+        assert result.selected[0].candidate.id == "hv"
+
+    # --- Issue 2: forensics uses iterative=False so budget trace stays coherent ---
+
+    def test_forensics_selected_matches_budget_trace(self):
+        """Every candidate marked 'selected' in the budget trace must also appear
+        in result.selected, and vice versa — i.e., no contradiction."""
+        from psi_loop.models import TaskDefinition
+        task = TaskDefinition(
+            id="coherence-check",
+            goal="design retry strategy with backoff",
+            current_context=["We use fixed delays today."],
+            max_tokens=80,
+            candidates=[
+                make_candidate("A", "Use exponential backoff with jitter on retry"),
+                make_candidate("B", "Retry with exponential backoff and add jitter between attempts"),
+                make_candidate("C", "Add a dead-letter queue for messages that exhaust retries"),
+                make_candidate("D", "Emit a metric on every retry attempt for observability"),
+            ],
+        )
+        forensics = build_task_forensics(task)
+
+        for selector in (forensics.baseline, forensics.psi0):
+            trace_selected_ids = {
+                item.candidate.candidate.id
+                for item in selector.budget_trace
+                if item.reason == "selected"
+            }
+            result_selected_ids = {sc.candidate.id for sc in selector.selected}
+            assert trace_selected_ids == result_selected_ids, (
+                f"{selector.name}: budget trace selected={trace_selected_ids} "
+                f"!= result selected={result_selected_ids}"
+            )
+
+    def test_forensics_no_candidate_selected_but_traced_dropped(self):
+        """A candidate in result.selected must never appear as 'would_exceed_budget'
+        or 'too_large' in the budget trace of the same selector."""
+        from psi_loop.models import TaskDefinition
+        task = TaskDefinition(
+            id="no-ghost-drops",
+            goal="retry backoff queue",
+            current_context=[],
+            max_tokens=60,
+            candidates=[
+                make_candidate("A", "retry backoff jitter"),
+                make_candidate("B", "dead-letter queue overflow"),
+                make_candidate("C", "idempotency key deduplication retry"),
+            ],
+        )
+        forensics = build_task_forensics(task)
+
+        for selector in (forensics.baseline, forensics.psi0):
+            selected_ids = {sc.candidate.id for sc in selector.selected}
+            for trace_item in selector.budget_trace:
+                cid = trace_item.candidate.candidate.id
+                if cid in selected_ids:
+                    assert trace_item.reason == "selected", (
+                        f"{selector.name}: {cid} is in selected but trace says {trace_item.reason}"
+                    )


### PR DESCRIPTION
## Summary

- **Forensics in `__all__`** — `build_task_forensics` and `render_task_forensics` were unreachable via top-level import; now exported
- **`BowEmbedder` L2 normalization** — vectors are now unit-length, removing document-length bias from centroid/surprise calculations; short and long chunks contribute equally
- **Near-tie comment fix** — corrected the comment to accurately describe the floor-division bucket guarantee (was claiming a per-pair guarantee it doesn't enforce)
- **Iterative selection (default)** — `select_context` and `PsiLoop.select` now re-score remaining candidates after each pick, appending the selected candidate to the running context first; `iterative=False` restores original behaviour

## Test plan

- [x] 169 tests pass (`pytest`) — 31 new targeted tests for all four fixes, 92 broader review tests, 46 original tests
- [x] Benchmark results unchanged — same win/tie/loss counts as pre-fix on all 14 benchmark tasks
- [x] `iterative=False` produces identical output to original `fit_to_budget` path
- [x] `from psi_loop import build_task_forensics, render_task_forensics` works at top level
- [x] BowEmbedder vectors are unit-norm; identical candidate against identical context gives surprise=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)